### PR TITLE
EWMA for micro units + artillery import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-bot.js
-*.tsbuildinfo
+build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
     "[typescript]": {
         // The bot.land editor uses 4 spaces.
         "editor.tabSize": 4
+    },
+    "files.exclude": {
+        "node_modules/": true
     }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,7 @@
             "args": [
                 "-i",
                 "s/var //g",
-                "MissileKite/bot.js"
+                "build/MissileKite.js"
             ],
             "group": "build",
             "dependsOn": [
@@ -42,7 +42,7 @@
             "args": [
                 "-i",
                 "s/var //g",
-                "ZapKite/bot.js"
+                "build/ZapKite.js"
             ],
             "group": {
                 "kind": "build",
@@ -69,7 +69,31 @@
             "args": [
                 "-i",
                 "s/var //g",
-                "SmartMelee/bot.js"
+                "build/SmartMelee.js"
+            ],
+            "group": "build",
+            "dependsOn": [
+                "SmartMelee compile"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "ArtilleryMicro compile",
+            "type": "typescript",
+            "tsconfig": "ArtilleryMicro/tsconfig.json",
+            "problemMatcher": [
+                "$tsc"
+            ],
+            "group": "build"
+        },
+        {
+            "label": "ArtilleryMicro output",
+            "type": "shell",
+            "command": "sed",
+            "args": [
+                "-i",
+                "s/var //g",
+                "build/ArtilleryMicro.js"
             ],
             "group": "build",
             "dependsOn": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -100,6 +100,30 @@
                 "ArtilleryMicro compile"
             ],
             "problemMatcher": []
+        },
+        {
+            "label": "AggroMiner compile",
+            "type": "typescript",
+            "tsconfig": "AggroMiner/tsconfig.json",
+            "problemMatcher": [
+                "$tsc"
+            ],
+            "group": "build"
+        },
+        {
+            "label": "AggroMiner output",
+            "type": "shell",
+            "command": "sed",
+            "args": [
+                "-i",
+                "s/var //g",
+                "build/AggroMiner.js"
+            ],
+            "group": "build",
+            "dependsOn": [
+                "AggroMiner compile"
+            ],
+            "problemMatcher": []
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -97,7 +97,7 @@
             ],
             "group": "build",
             "dependsOn": [
-                "SmartMelee compile"
+                "ArtilleryMicro compile"
             ],
             "problemMatcher": []
         }

--- a/AggroMiner/AggroMiner.ts
+++ b/AggroMiner/AggroMiner.ts
@@ -1,0 +1,99 @@
+/**
+ * Aggro Miner
+ *
+ * Draws enemy units out and blows them to high heaven. Better in groups.
+ *
+ * Loadout: regen 3, thrusters 3, mine 1
+ * To be tougher, can substitute armor for thrusters or regen.
+ */
+const update = function() {
+    // Controls EWMA limits: for mine-only we want to keep this pretty tight
+    const TEAM_MIN_DIST = 2.5;
+    const TEAM_MAX_DIST = 6;
+
+    if (isAttacker) {
+        attackerUpdateLocation(x, y);
+        checkTeamCentroidMove(TEAM_MIN_DIST, TEAM_MAX_DIST);
+    }
+
+    // Do we see anything nearby?
+    const closestEnemy = findEntity(
+        ENEMY,
+        ANYTHING,
+        SORT_BY_DISTANCE,
+        SORT_ASCENDING
+    );
+    if (!exists(closestEnemy)) {
+        tryShieldFriendlyBots(4);
+        // If we don't see anything and can activate sensors, go ahead.
+        tryActivateSensors();
+        // Sensors and still don't see anything?
+        // Defenders can be more aggresive, attackers have mines.
+        if (isAttacker) {
+            if (!canLayMine()) figureItOut();
+            else tryLayMine();
+        } else {
+            defenderMove();
+        }
+    }
+
+    const closestEnemyBot = findEntity(
+        ENEMY,
+        BOT,
+        SORT_BY_DISTANCE,
+        SORT_ASCENDING
+    );
+    if (!exists(closestEnemyBot)) {
+        tryShieldFriendlyBots(4);
+        tryActivateSensors();
+        if (isAttacker) {
+            if (!canLayMine()) figureItOut();
+            else tryLayMine();
+        } else {
+            defenderMove();
+        }
+    }
+
+    // Now we know there's a bot nearby.
+    setEnemySeen(closestEnemyBot);
+
+    const allEnemyBots = findEntities(ENEMY, BOT, false);
+    const numEnemyBots = size(allEnemyBots);
+    const enemyBotDistance = getDistanceTo(closestEnemyBot);
+
+    const allFriendlyBots = findEntities(IS_OWNED_BY_ME, BOT, true);
+    const numFriendlyBots = size(allFriendlyBots);
+
+    // Only evade lasers on defense. Otherwise, keeping enemy bots at range 5
+    // will be fine with regen.
+    if (numFriendlyBots < 6) tryEvadeLasers(closestEnemyBot, numEnemyBots, 5);
+
+    if (enemyBotDistance < 5.1) {
+        tryReflect();
+        if (!isShielded()) tryShieldSelf();
+        else tryShieldFriendlyBots(4);
+    }
+
+    // Generally evade anything closer than 5. Make it as hard to shoot as possible.
+    const evadeThreshold = 5.1;
+
+    if (enemyBotDistance < evadeThreshold) {
+        // The mining continuum:
+        // Further enemies = mine
+        // Closer enemies = run (e.g. zappers)
+        if (enemyBotDistance == 5) tryLayMine();
+        else if (enemyBotDistance == 4 && percentChance(90)) tryLayMine();
+        else if (enemyBotDistance == 3 && percentChance(60)) tryLayMine();
+        else if (enemyBotDistance == 2 && percentChance(40)) tryLayMine();
+
+        // Try evasive maneuvers
+        // TODO: might be okay to just evade in a straight line here given regen
+        tryEvadeEnemy(closestEnemyBot, numEnemyBots);
+        // Can't evade, just mine
+        tryLayMine();
+        // If we can't run, we can whack someone as a last resort.
+        tryMeleeSmart();
+    }
+
+    defaultMove();
+};

--- a/AggroMiner/tsconfig.json
+++ b/AggroMiner/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es3",
+    "module": "none",
+    "removeComments": true,
+    "sourceMap": false,
+    "outFile": "../build/AggroMiner.js"
+  },
+  "files": [
+    "AggroMiner.ts"
+  ],
+  "include": [
+    "../lib/**/*"
+  ]
+}

--- a/ArtilleryMicro/ArtilleryMicro.ts
+++ b/ArtilleryMicro/ArtilleryMicro.ts
@@ -31,7 +31,9 @@ const update = function() {
             if (AGGRESSIVE) figureItOut();
             // But this is useful for dealing with other artillery
             else if (areSensorsActivated()) figureItOut();
-            else return;
+            // This is important to stop artillery from being effin slow
+            else if (!canLayMine()) figureItOut();
+            else tryLayMine();
         } else {
             defenderMove(true);
         }
@@ -49,7 +51,8 @@ const update = function() {
         if (isAttacker) {
             if (AGGRESSIVE) figureItOut();
             else if (areSensorsActivated()) figureItOut();
-            else return;
+            else if (!canLayMine()) figureItOut();
+            else tryLayMine();
         } else {
             defenderMove(true);
         }
@@ -97,9 +100,15 @@ const update = function() {
     // There's an enemy nearby but we can't attack it, or there are too many.
     // Artillery has min range 5, max range 7
     if (enemyBotDistance < evadeThreshold) {
-        tryLayMine();
+        // This is reversed from missiles. Because artillery has no short range it
+        // should definitely mine when enemies get close.
+        if (enemyBotDistance < 3.1 && percentChance(80)) tryLayMine();
+        else if (enemyBotDistance <= 4.1 && percentChance(50)) tryLayMine();
+
         // Try evasive maneuvers
         tryEvadeEnemy(closestEnemyBot, numEnemyBots);
+        // Can't evade, just mine
+        tryLayMine();
     }
 
     tryFireArtillery();

--- a/ArtilleryMicro/ArtilleryMicro.ts
+++ b/ArtilleryMicro/ArtilleryMicro.ts
@@ -1,14 +1,17 @@
 /**
  * Micro artillery
  *
- * Defense loadout: artillery 3, shield 3, thrusters 1
- * Offense loadout: artillery 3, regen 3, thrusters 1
+ * Defense loadout: artillery 3, shield/reflect 3, thrusters 1
+ * Offense loadout: artillery 2, regen 3, thrusters 1, mine 1
  */
 const update = function() {
+    // Controls whether artillery attack without sensors
+    const AGGRESSIVE = false;
+
     attackerUpdateLocation(x, y);
 
     // TODO artillery potshot? It's less important because it probably won't
-    // hit.
+    // hit anything.
 
     // Do we see anything nearby?
     const closestEnemy = findEntity(
@@ -22,10 +25,12 @@ const update = function() {
         // If we don't see anything and can activate sensors, go ahead.
         tryActivateSensors();
         // Sensors and still don't see anything?
-        // Defenders can be more aggresive than attackers.
+        // Defenders can be more aggresive, attackers have mines.
         if (isAttacker) {
-            // Half the time don't advance without sensors
-            if (areSensorsActivated() || percentChance(50)) defaultMove();
+            // We have landmines, no more need to wait for sensors
+            if (AGGRESSIVE) figureItOut();
+            // But this is useful for dealing with other artillery
+            else if (areSensorsActivated()) figureItOut();
             else return;
         } else {
             defenderMove(true);
@@ -42,7 +47,8 @@ const update = function() {
         tryShieldFriendlyBots(4);
         tryActivateSensors();
         if (isAttacker) {
-            if (areSensorsActivated() || percentChance(50)) defaultMove();
+            if (AGGRESSIVE) figureItOut();
+            else if (areSensorsActivated()) figureItOut();
             else return;
         } else {
             defenderMove(true);
@@ -59,20 +65,17 @@ const update = function() {
     const allFriendlyBots = findEntities(IS_OWNED_BY_ME, BOT, true);
     const numFriendlyBots = size(allFriendlyBots);
 
+    // Don't stand in range of lasers. On defense when there are lots of allies,
+    // don't evade lasers though, just let the tanks reflect them. Welcome
+    // lasers if we have mines.
+    if (!canLayMine() && numFriendlyBots < 6)
+        tryEvadeLasers(closestEnemyBot, numEnemyBots, 5);
+
     if (enemyBotDistance < 5.1) {
         tryReflect();
         if (!isShielded()) tryShieldSelf();
         else tryShieldFriendlyBots(4);
     }
-
-    // Don't stand in range of lasers. On defense when there are lots of allies,
-    // don't evade lasers, just let the tanks reflect them.
-    if (numFriendlyBots < 6) tryEvadeLasers(closestEnemyBot, numEnemyBots, 7);
-
-    // If we're cornered and have melee we can try to whack it. This will
-    // probably become obsolete though.
-    tryMeleeSmart();
-    if (willMeleeHit()) melee();
 
     // Not in melee range...can we shoot something if there aren't too many enemies around?
     // TODO add shared variable for retreating
@@ -83,60 +86,23 @@ const update = function() {
     if (numEnemyBots <= 2 || (!isAttacker && numFriendlyBots >= 5)) {
         tryFireArtillery();
     }
+    // I think we can ignore all the above and always shoot, cause landmines
+    // Should we even have this code up here?
 
+    // Generally evade anything closer than 5. On defense we have tanks, on
+    // attack we have mines.
     let evadeThreshold = 6.5;
-    // On defense we can just stay at max range
-    if (!isAttacker) evadeThreshold = 4.5;
+    if (AGGRESSIVE) evadeThreshold = 4.5;
 
     // There's an enemy nearby but we can't attack it, or there are too many.
     // Artillery has min range 5, max range 7
     if (enemyBotDistance < evadeThreshold) {
-        // TODO a lot of this code is equipment that artillery won't have, now
-        // that we are planning support units; it should be cleaned up.
-
-        // Protect against missiles if we have reflection
-        if (enemyBotDistance <= 4) tryReflect();
-        // If they're really close and we can cloak, do that
-        if (enemyBotDistance < 4) tryCloak();
-
-        if (enemyBotDistance < 2.1) tryZap();
-
-        if (enemyBotDistance <= 2 && !isCloaked() && canCharge()) {
-            // We're backed into a corner. Charge!!
-            // We'll have already tried melee above, so here we'd just move
-            // toward it.
-            pursue(closestEnemyBot);
-        }
-
-        const cornerDist = distanceToCorner();
-        // Charge more aggresively if cornered
-        if (
-            enemyBotDistance <= 3 &&
-            cornerDist <= 2 &&
-            !isCloaked &&
-            canCharge()
-        ) {
-            // We're backed into a corner. Charge!!
-            pursue(closestEnemyBot);
-        }
-
-        // If the enemy somehow got close, we can shoot it some of the time
-        // TODO better handle when we should shoot and when we should run
-        if (enemyBotDistance <= 3 && numEnemyBots <= 1 && percentChance(50))
-            tryFireMissiles();
-
+        tryLayMine();
         // Try evasive maneuvers
         tryEvadeEnemy(closestEnemyBot, numEnemyBots);
     }
 
     tryFireArtillery();
     tryActivateSensors();
-
     defaultMove(true);
-};
-
-const distanceToCorner = function(): number {
-    const distTopLeft = x + y;
-    const distBotLeft = x + (arenaHeight - 1 - y);
-    return min(distTopLeft, distBotLeft);
 };

--- a/ArtilleryMicro/ArtilleryMicro.ts
+++ b/ArtilleryMicro/ArtilleryMicro.ts
@@ -7,8 +7,12 @@
 const update = function() {
     // Controls whether artillery attack without sensors
     const AGGRESSIVE = false;
+    // Controls EWMA limits: these can be a bit higher than for missiles
+    const TEAM_MIN_DIST = 3.5;
+    const TEAM_MAX_DIST = 7;
 
     attackerUpdateLocation(x, y);
+    checkTeamCentroidMove(TEAM_MIN_DIST, TEAM_MAX_DIST);
 
     // TODO artillery potshot? It's less important because it probably won't
     // hit anything.
@@ -82,11 +86,14 @@ const update = function() {
 
     // Not in melee range...can we shoot something if there aren't too many enemies around?
     // TODO add shared variable for retreating
-    // TODO: if other artillery in range, don't stand still
-    // TODO bug: will keep shooting at far enemy even if getting attacked by close enemy
+    // TODO: if other artillery in range, don't stand still, zig zag
+
     // TODO only for attacker do we count the bots here
-    // Shoot if we see less than 2 enemies, or we're defending with buddies
-    if (numEnemyBots <= 2 || (!isAttacker && numFriendlyBots >= 5)) {
+
+    // Need <= 1 or will keep shooting at far enemy even if getting attacked by
+    // close enemy, and its better to mine. Can shoot if we're defending with
+    // buddies
+    if (numEnemyBots <= 1 || (!isAttacker && numFriendlyBots >= 5)) {
         tryFireArtillery();
     }
     // I think we can ignore all the above and always shoot, cause landmines

--- a/ArtilleryMicro/ArtilleryMicro.ts
+++ b/ArtilleryMicro/ArtilleryMicro.ts
@@ -11,11 +11,10 @@ const update = function() {
     const TEAM_MIN_DIST = 3.5;
     const TEAM_MAX_DIST = 7;
 
-    attackerUpdateLocation(x, y);
-    checkTeamCentroidMove(TEAM_MIN_DIST, TEAM_MAX_DIST);
-
-    // TODO artillery potshot? It's less important because it probably won't
-    // hit anything.
+    if (isAttacker) {
+        attackerUpdateLocation(x, y);
+        checkTeamCentroidMove(TEAM_MIN_DIST, TEAM_MAX_DIST);
+    }
 
     // Do we see anything nearby?
     const closestEnemy = findEntity(

--- a/ArtilleryMicro/ArtilleryMicro.ts
+++ b/ArtilleryMicro/ArtilleryMicro.ts
@@ -1,0 +1,160 @@
+const update = function() {
+    // Do we see anything nearby?
+    const closestEnemy = findEntity(
+        ENEMY,
+        ANYTHING,
+        SORT_BY_DISTANCE,
+        SORT_ASCENDING
+    );
+    if (!exists(closestEnemy)) {
+        // Nope, default behavior
+        if (canActivateSensors()) activateSensors();
+
+        // Sensors and still don't see anything? Go ahead
+        // Otherwise, don't do something dumb
+        if (areSensorsActivated()) figureItOut();
+        else return;
+    }
+
+    tryReflect();
+
+    // Something's nearby...can we whack it?
+    tryMeleeSmart();
+    if (willMeleeHit()) melee();
+
+    const closestEnemyBot = findEntity(
+        ENEMY,
+        BOT,
+        SORT_BY_DISTANCE,
+        SORT_ASCENDING
+    );
+    if (!exists(closestEnemyBot)) {
+        // It's not a bot, so just attack blindly
+        if (canActivateSensors()) activateSensors();
+        if (areSensorsActivated()) figureItOut();
+        else return;
+    }
+
+    const enemyBotDistance = getDistanceTo(closestEnemyBot);
+    const allEnemyBots = findEntities(ENEMY, BOT, false);
+    const numEnemyBots = size(allEnemyBots);
+
+    // Don't stand in range of lasers
+    tryEvadeLasers(closestEnemyBot, numEnemyBots);
+
+    if (x == closestEnemyBot.x) {
+        // TODO hack for fixing the bouncing back and forth issue
+        if (enemyBotDistance >= 7) {
+            if (y > closestEnemyBot.y && canMove("up")) move("up");
+            else if (y < closestEnemyBot.y && canMove("down")) move("down");
+        }
+        // Otherwise, move sideways
+        if (canMove("backward")) move("backward");
+        if (canMove("forward")) move("forward");
+    }
+    if (y == closestEnemyBot.y) {
+        // Move up or down randomly if both directions are available
+        if (canMove("up") && canMove("down")) {
+            if (percentChance(50)) move("up");
+            move("down");
+        }
+        if (canMove("up")) move("up");
+        if (canMove("down")) move("down");
+    }
+
+    // Not in melee range...can we shoot something if there aren't too many enemies around?
+    // TODO add shared variable for retreating
+    // TODO: if other artillery in range, don't stand still
+    // TODO bug: will keep shooting at far enemy even if getting attacked by close enemy
+    // TODO only for attacker do we count the bots here
+    if (numEnemyBots <= 2) {
+        if (willArtilleryHit()) {
+            const gank = findEntity(ENEMY, BOT, SORT_BY_LIFE, SORT_ASCENDING);
+            if (getDistanceTo(gank) <= 7) fireArtillery(gank);
+            fireArtillery();
+        }
+    }
+
+    // There's an enemy nearby but we can't attack it, or there are too many.
+    // This assumes we are armed with artillery, which has min range 7, max range 10
+    // TODO update evade distance for attacker/defender
+    if (enemyBotDistance < 6.5) {
+        debugLog(x + " " + y + " evading");
+        // Too close for comfort, let's try to get away
+        if (enemyBotDistance < 4 && canCloak()) {
+            // If they're really close and we can cloak, do that
+            cloak();
+        }
+        if (enemyBotDistance <= 4 && canReflect()) {
+            // Protect against missiles if we have reflection
+            reflect();
+        }
+        if (enemyBotDistance < 2.1 && canZap()) {
+            zap();
+        }
+
+        if (enemyBotDistance <= 2 && !isCloaked() && canCharge()) {
+            // We're backed into a corner. Charge!!
+            pursue(closestEnemyBot);
+        }
+
+        const cornerDist = distanceToCorner();
+        // Charge more aggresively if cornered
+        if (enemyBotDistance <= 3 && cornerDist <= 2 && canCharge()) {
+            // We're backed into a corner. Charge!!
+            pursue(closestEnemyBot);
+        }
+
+        // If the enemy somehow got close, we can shoot it some of the time
+        // TODO better handle when we should shoot and when we should run
+        if (
+            enemyBotDistance <= 3 &&
+            willMissilesHit() &&
+            numEnemyBots <= 1 &&
+            percentChance(50)
+        ) {
+            const gank = findEntity(ENEMY, BOT, SORT_BY_LIFE, SORT_ASCENDING);
+            if (getDistanceTo(gank) <= 3) fireMissiles(gank);
+            fireMissiles();
+        }
+
+        // Move away from the bot, preferably toward a border
+        // TODO artillery needs to be able to move forward
+
+        // We're diagonally (?) positioned from the enemy. Go in the direction with more space.
+        if (canMove("backward") && x <= closestEnemyBot.x) {
+            move("backward");
+        }
+        if (canMove("up") && y <= closestEnemyBot.y) {
+            move("up");
+        }
+        if (canMove("down") && y >= closestEnemyBot.y) {
+            move("down");
+        }
+        if (canMove("backward")) {
+            if (numEnemyBots > 1) move("backward");
+        }
+        if (canMove("forward") && x >= closestEnemyBot.x && numEnemyBots <= 1) {
+            move("forward");
+        }
+        if (canMove("backward")) {
+            move("backward");
+        }
+    }
+
+    if (willMissilesHit()) {
+        const gank = findEntity(ENEMY, BOT, SORT_BY_LIFE, SORT_ASCENDING);
+        if (getDistanceTo(gank) <= 3) fireMissiles(gank);
+        fireMissiles();
+    }
+
+    if (canActivateSensors()) activateSensors();
+    // Random move
+    move();
+};
+
+const distanceToCorner = function(): number {
+    const distTopLeft = x + y;
+    const distBotLeft = x + (arenaHeight - 1 - y);
+    return min(distTopLeft, distBotLeft);
+};

--- a/ArtilleryMicro/ArtilleryMicro.ts
+++ b/ArtilleryMicro/ArtilleryMicro.ts
@@ -1,5 +1,14 @@
+/**
+ * Micro artillery
+ *
+ * Defense loadout: artillery 3, shield 3, thrusters 1
+ * Offense loadout: artillery 3, regen 3, thrusters 1
+ */
 const update = function() {
     attackerUpdateLocation(x, y);
+
+    // TODO artillery potshot? It's less important because it probably won't
+    // hit.
 
     // Do we see anything nearby?
     const closestEnemy = findEntity(
@@ -19,7 +28,7 @@ const update = function() {
             if (areSensorsActivated() || percentChance(50)) defaultMove();
             else return;
         } else {
-            defenderMove();
+            defenderMove(true);
         }
     }
 
@@ -36,7 +45,7 @@ const update = function() {
             if (areSensorsActivated() || percentChance(50)) defaultMove();
             else return;
         } else {
-            defenderMove();
+            defenderMove(true);
         }
     }
 
@@ -123,7 +132,7 @@ const update = function() {
     tryFireArtillery();
     tryActivateSensors();
 
-    defaultMove();
+    defaultMove(true);
 };
 
 const distanceToCorner = function(): number {

--- a/ArtilleryMicro/ArtilleryMicro.ts
+++ b/ArtilleryMicro/ArtilleryMicro.ts
@@ -1,4 +1,6 @@
 const update = function() {
+    attackerUpdateLocation(x, y);
+
     // Do we see anything nearby?
     const closestEnemy = findEntity(
         ENEMY,
@@ -7,20 +9,19 @@ const update = function() {
         SORT_ASCENDING
     );
     if (!exists(closestEnemy)) {
-        // Nope, default behavior
-        if (canActivateSensors()) activateSensors();
-
-        // Sensors and still don't see anything? Go ahead
-        // Otherwise, don't do something dumb
-        if (areSensorsActivated()) figureItOut();
-        else return;
+        tryShieldFriendlyBots(4);
+        // If we don't see anything and can activate sensors, go ahead.
+        tryActivateSensors();
+        // Sensors and still don't see anything?
+        // Defenders can be more aggresive than attackers.
+        if (isAttacker) {
+            // Half the time don't advance without sensors
+            if (areSensorsActivated() || percentChance(50)) defaultMove();
+            else return;
+        } else {
+            defenderMove();
+        }
     }
-
-    tryReflect();
-
-    // Something's nearby...can we whack it?
-    tryMeleeSmart();
-    if (willMeleeHit()) melee();
 
     const closestEnemyBot = findEntity(
         ENEMY,
@@ -29,128 +30,100 @@ const update = function() {
         SORT_ASCENDING
     );
     if (!exists(closestEnemyBot)) {
-        // It's not a bot, so just attack blindly
-        if (canActivateSensors()) activateSensors();
-        if (areSensorsActivated()) figureItOut();
-        else return;
+        tryShieldFriendlyBots(4);
+        tryActivateSensors();
+        if (isAttacker) {
+            if (areSensorsActivated() || percentChance(50)) defaultMove();
+            else return;
+        } else {
+            defenderMove();
+        }
     }
 
-    const enemyBotDistance = getDistanceTo(closestEnemyBot);
+    // Now we know there's a bot nearby.
+    setEnemySeen(closestEnemyBot);
+
     const allEnemyBots = findEntities(ENEMY, BOT, false);
     const numEnemyBots = size(allEnemyBots);
+    const enemyBotDistance = getDistanceTo(closestEnemyBot);
 
-    // Don't stand in range of lasers
-    tryEvadeLasers(closestEnemyBot, numEnemyBots);
+    const allFriendlyBots = findEntities(IS_OWNED_BY_ME, BOT, true);
+    const numFriendlyBots = size(allFriendlyBots);
 
-    if (x == closestEnemyBot.x) {
-        // TODO hack for fixing the bouncing back and forth issue
-        if (enemyBotDistance >= 7) {
-            if (y > closestEnemyBot.y && canMove("up")) move("up");
-            else if (y < closestEnemyBot.y && canMove("down")) move("down");
-        }
-        // Otherwise, move sideways
-        if (canMove("backward")) move("backward");
-        if (canMove("forward")) move("forward");
+    if (enemyBotDistance < 5.1) {
+        tryReflect();
+        if (!isShielded()) tryShieldSelf();
+        else tryShieldFriendlyBots(4);
     }
-    if (y == closestEnemyBot.y) {
-        // Move up or down randomly if both directions are available
-        if (canMove("up") && canMove("down")) {
-            if (percentChance(50)) move("up");
-            move("down");
-        }
-        if (canMove("up")) move("up");
-        if (canMove("down")) move("down");
-    }
+
+    // Don't stand in range of lasers. On defense when there are lots of allies,
+    // don't evade lasers, just let the tanks reflect them.
+    if (numFriendlyBots < 6) tryEvadeLasers(closestEnemyBot, numEnemyBots, 7);
+
+    // If we're cornered and have melee we can try to whack it. This will
+    // probably become obsolete though.
+    tryMeleeSmart();
+    if (willMeleeHit()) melee();
 
     // Not in melee range...can we shoot something if there aren't too many enemies around?
     // TODO add shared variable for retreating
     // TODO: if other artillery in range, don't stand still
     // TODO bug: will keep shooting at far enemy even if getting attacked by close enemy
     // TODO only for attacker do we count the bots here
-    if (numEnemyBots <= 2) {
-        if (willArtilleryHit()) {
-            const gank = findEntity(ENEMY, BOT, SORT_BY_LIFE, SORT_ASCENDING);
-            if (getDistanceTo(gank) <= 7) fireArtillery(gank);
-            fireArtillery();
-        }
+    // Shoot if we see less than 2 enemies, or we're defending with buddies
+    if (numEnemyBots <= 2 || (!isAttacker && numFriendlyBots >= 5)) {
+        tryFireArtillery();
     }
 
+    let evadeThreshold = 6.5;
+    // On defense we can just stay at max range
+    if (!isAttacker) evadeThreshold = 4.5;
+
     // There's an enemy nearby but we can't attack it, or there are too many.
-    // This assumes we are armed with artillery, which has min range 7, max range 10
-    // TODO update evade distance for attacker/defender
-    if (enemyBotDistance < 6.5) {
-        debugLog(x + " " + y + " evading");
-        // Too close for comfort, let's try to get away
-        if (enemyBotDistance < 4 && canCloak()) {
-            // If they're really close and we can cloak, do that
-            cloak();
-        }
-        if (enemyBotDistance <= 4 && canReflect()) {
-            // Protect against missiles if we have reflection
-            reflect();
-        }
-        if (enemyBotDistance < 2.1 && canZap()) {
-            zap();
-        }
+    // Artillery has min range 5, max range 7
+    if (enemyBotDistance < evadeThreshold) {
+        // TODO a lot of this code is equipment that artillery won't have, now
+        // that we are planning support units; it should be cleaned up.
+
+        // Protect against missiles if we have reflection
+        if (enemyBotDistance <= 4) tryReflect();
+        // If they're really close and we can cloak, do that
+        if (enemyBotDistance < 4) tryCloak();
+
+        if (enemyBotDistance < 2.1) tryZap();
 
         if (enemyBotDistance <= 2 && !isCloaked() && canCharge()) {
             // We're backed into a corner. Charge!!
+            // We'll have already tried melee above, so here we'd just move
+            // toward it.
             pursue(closestEnemyBot);
         }
 
         const cornerDist = distanceToCorner();
         // Charge more aggresively if cornered
-        if (enemyBotDistance <= 3 && cornerDist <= 2 && canCharge()) {
+        if (
+            enemyBotDistance <= 3 &&
+            cornerDist <= 2 &&
+            !isCloaked &&
+            canCharge()
+        ) {
             // We're backed into a corner. Charge!!
             pursue(closestEnemyBot);
         }
 
         // If the enemy somehow got close, we can shoot it some of the time
         // TODO better handle when we should shoot and when we should run
-        if (
-            enemyBotDistance <= 3 &&
-            willMissilesHit() &&
-            numEnemyBots <= 1 &&
-            percentChance(50)
-        ) {
-            const gank = findEntity(ENEMY, BOT, SORT_BY_LIFE, SORT_ASCENDING);
-            if (getDistanceTo(gank) <= 3) fireMissiles(gank);
-            fireMissiles();
-        }
+        if (enemyBotDistance <= 3 && numEnemyBots <= 1 && percentChance(50))
+            tryFireMissiles();
 
-        // Move away from the bot, preferably toward a border
-        // TODO artillery needs to be able to move forward
-
-        // We're diagonally (?) positioned from the enemy. Go in the direction with more space.
-        if (canMove("backward") && x <= closestEnemyBot.x) {
-            move("backward");
-        }
-        if (canMove("up") && y <= closestEnemyBot.y) {
-            move("up");
-        }
-        if (canMove("down") && y >= closestEnemyBot.y) {
-            move("down");
-        }
-        if (canMove("backward")) {
-            if (numEnemyBots > 1) move("backward");
-        }
-        if (canMove("forward") && x >= closestEnemyBot.x && numEnemyBots <= 1) {
-            move("forward");
-        }
-        if (canMove("backward")) {
-            move("backward");
-        }
+        // Try evasive maneuvers
+        tryEvadeEnemy(closestEnemyBot, numEnemyBots);
     }
 
-    if (willMissilesHit()) {
-        const gank = findEntity(ENEMY, BOT, SORT_BY_LIFE, SORT_ASCENDING);
-        if (getDistanceTo(gank) <= 3) fireMissiles(gank);
-        fireMissiles();
-    }
+    tryFireArtillery();
+    tryActivateSensors();
 
-    if (canActivateSensors()) activateSensors();
-    // Random move
-    move();
+    defaultMove();
 };
 
 const distanceToCorner = function(): number {

--- a/ArtilleryMicro/tsconfig.json
+++ b/ArtilleryMicro/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es3",
     "module": "none",
+    "removeComments": true,
     "sourceMap": false,
     "outFile": "../build/ArtilleryMicro.js"
   },

--- a/ArtilleryMicro/tsconfig.json
+++ b/ArtilleryMicro/tsconfig.json
@@ -2,12 +2,11 @@
   "compilerOptions": {
     "target": "es3",
     "module": "none",
-    "removeComments": true,
     "sourceMap": false,
-    "outFile": "../build/MissileKite.js"
+    "outFile": "../build/ArtilleryMicro.js"
   },
   "files": [
-    "MissileKite.ts"
+    "ArtilleryMicro.ts"
   ],
   "include": [
     "../lib/**/*"

--- a/MissileKite/MissileKite.ts
+++ b/MissileKite/MissileKite.ts
@@ -36,10 +36,12 @@ const update = function() {
         tryFireMissiles();
     }
 
-    // Update our location for the team average
-    attackerUpdateLocation(x, y);
-    // We want to give bots room to maneuver but not go too far away
-    checkTeamCentroidMove(TEAM_MIN_DIST, TEAM_MAX_DIST);
+    if (isAttacker) {
+        // Update our location for the team average
+        attackerUpdateLocation(x, y);
+        // We want to give bots room to maneuver but not go too far away
+        checkTeamCentroidMove(TEAM_MIN_DIST, TEAM_MAX_DIST);
+    }
 
     // Do we see anything nearby?
     const closestEnemy = findEntity(

--- a/MissileKite/MissileKite.ts
+++ b/MissileKite/MissileKite.ts
@@ -18,8 +18,8 @@
  * high reflect and no thrusters (it saves 1 reflection).
  */
 const update = function() {
-    // Update our location for the team average
-    attackerUpdateLocation(x, y);
+    const TEAM_MIN_DIST = 2.5;
+    const TEAM_MAX_DIST = 6.5;
 
     const state = getData();
     if (!exists(state)) {
@@ -35,6 +35,11 @@ const update = function() {
         // get their turns first before attackers (if not shielding above).
         tryFireMissiles();
     }
+
+    // Update our location for the team average
+    attackerUpdateLocation(x, y);
+    // We want to give bots room to maneuver but not go too far away
+    checkTeamCentroidMove(TEAM_MIN_DIST, TEAM_MAX_DIST);
 
     // Do we see anything nearby?
     const closestEnemy = findEntity(

--- a/MissileKite/MissileKite.ts
+++ b/MissileKite/MissileKite.ts
@@ -99,10 +99,11 @@ const update = function() {
         else tryShieldFriendlyBots(4);
     }
 
-    // Mine layers should not do it from too far, so they have time to lay mine
-    if (enemyBotDistance < 4.1) tryLayMine();
-    // When close: not every time, as this can cause us to slow down too much.
-    if (enemyBotDistance < 3.1 && percentChance(30)) tryLayMine();
+    // Because mine laying is always available, we have to control how
+    // aggressively it happens, so we don't get bogged down.
+    if (enemyBotDistance == 5) tryLayMine();
+    else if (enemyBotDistance == 4 && percentChance(70)) tryLayMine();
+    else if (enemyBotDistance == 3 && percentChance(40)) tryLayMine();
 
     // Heuristic: on defense when there are lots of allies, don't evade lasers,
     // just let the tanks do that. We attack with up to 5 bots so this is a

--- a/MissileKite/MissileKite.ts
+++ b/MissileKite/MissileKite.ts
@@ -18,6 +18,9 @@
  * high reflect and no thrusters (it saves 1 reflection).
  */
 const update = function() {
+    // Update our location for the team average
+    attackerUpdateLocation(x, y);
+
     const state = getData();
     if (!exists(state)) {
         // Need to save in case we reach a terminator

--- a/MissileKite/MissileKite.ts
+++ b/MissileKite/MissileKite.ts
@@ -88,16 +88,15 @@ const update = function() {
     // Heuristic: on defense don't evade lasers, just let the tanks do that.
     // Mine layers don't evade lasers, you want them to come follow in.
     if (!canLayMine() && numFriendlyBots < 5)
-        tryEvadeLasers(closestEnemyBot, numEnemyBots);
+        tryEvadeLasers(closestEnemyBot, numEnemyBots, 4);
 
-    // Protect against missiles/lasers if we have reflection
+    // Protect against missiles/lasers if we have reflection. Note: protect
+    // first before we try to evade, otherwise we end up doing a lot of evasion
+    // without shield and sometimes that gets messy.
     if (enemyBotDistance < 5.1) {
         tryReflect();
-        if (!isShielded()) {
-            tryShieldSelf();
-        } else {
-            tryShieldFriendlyBots(4);
-        }
+        if (!isShielded()) tryShieldSelf();
+        else tryShieldFriendlyBots(4);
     }
 
     // Mine layers should not do it from too far, so they have time to lay mine
@@ -105,20 +104,23 @@ const update = function() {
     // When close: not every time, as this can cause us to slow down too much.
     if (enemyBotDistance < 3.1 && percentChance(30)) tryLayMine();
 
+    // Heuristic: on defense when there are lots of allies, don't evade lasers,
+    // just let the tanks do that. We attack with up to 5 bots so this is a
+    // decent heuristic.
+    if (numFriendlyBots < 6) tryEvadeLasers(closestEnemyBot, numEnemyBots, 4);
+
     // Prefer to be farther but shoot from closer when we have advantage
     // Farther is better to avoid zappers / inferno zappers, but does less damage
     // > 3 also avoids Level 2 and lower missiles, so we can kite those.
     // At least on bigger maps.
 
     let evadeThreshold = 3.1;
-    // Under some conditions shoot from closer to get more shots:
-    // - only one enemy bot (especially if there are more of us)
-    // - we're getting backed into the wall (often ends up running around)
-    //
-    // TODO update for attackers & defenders
-    // TODO defenders should always shoot if friendly bots >= 5, cuz DPS...don't run.
-    // TODO evading at 2 can still be bad because damage from zappers
-    if (numEnemyBots <= 1 || x <= 2) evadeThreshold = 2.9;
+    // Previously we'd evade less if there was only 1 enemy bot, but this was
+    // pretty vulnerable to zappers, taking damage when we shouldn't. For now
+    // only evade less when we are backed into the wall.
+
+    // Defenders should use lower threshold if friendly bots >= 5; probably tanks in front
+    if (x <= 2 || (!isAttacker && numFriendlyBots >= 5)) evadeThreshold = 2.9;
 
     if (enemyBotDistance < evadeThreshold) {
         if (percentChance(25)) tryLayMine();

--- a/SmartMelee/tsconfig.json
+++ b/SmartMelee/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "none",
     "removeComments": true,
     "sourceMap": false,
-    "outFile": "bot.js"
+    "outFile": "../build/SmartMelee.js"
   },
   "files": [
     "SmartMelee.ts"

--- a/ZapKite/tsconfig.json
+++ b/ZapKite/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "none",
     "removeComments": true,
     "sourceMap": false,
-    "outFile": "bot.js"
+    "outFile": "../build/ZapKite.js"
   },
   "files": [
     "ZapKite.ts"

--- a/legacy/ArtilleryMicro.js
+++ b/legacy/ArtilleryMicro.js
@@ -1,0 +1,158 @@
+distanceToCorner = function() {
+    distTopLeft = x + y;
+    distBotLeft = x + (arenaHeight - 1 - y);
+    return min(distTopLeft, distBotLeft);
+};
+
+update = function() {
+    // Do we see anything nearby?
+    closestEnemy = findEntity(
+        ENEMY,
+        ANYTHING,
+        SORT_BY_DISTANCE,
+        SORT_ASCENDING
+    );
+    if (!exists(closestEnemy)) {
+        // Nope, default behavior
+        if (canActivateSensors()) activateSensors();
+
+        // Sensors and still don't see anything? Go ahead
+        // Otherwise, don't do something dumb
+        if (areSensorsActivated()) figureItOut();
+        else return;
+    }
+
+    if (canReflect()) {
+        reflect();
+    }
+
+    // Something's nearby...can we whack it?
+    if (willMeleeHit()) {
+        // gank = findEntity(ENEMY, BOT, SORT_BY_LIFE, SORT_ASCENDING);
+        // if (getDistanceTo(gank) <= 2 && canCharge()) melee(gank);
+        // else if (getDistanceTo(gank) <= 1) melee(gank);
+        melee();
+    }
+
+    closestEnemyBot = findEntity(ENEMY, BOT, SORT_BY_DISTANCE, SORT_ASCENDING);
+    if (!exists(closestEnemyBot)) {
+        // It's not a bot, so just attack blindly
+        if (canActivateSensors()) activateSensors();
+
+        if (areSensorsActivated()) figureItOut();
+        else return;
+    }
+
+    allEnemyBots = findEntities(ENEMY, BOT, false);
+    enemyBotDistance = getDistanceTo(closestEnemyBot);
+    numEnemyBots = size(allEnemyBots);
+
+    // Don't stand in range of lasers
+    if (x == closestEnemyBot.x) {
+        // TODO hack for fixing the bouncing back and forth issue
+        if (enemyBotDistance >= 7) {
+            if (y > closestEnemyBot.y && canMove("up")) move("up");
+            else if (y < closestEnemyBot.y && canMove("down")) move("down");
+        }
+        // Otherwise, move sideways
+        if (canMove("backward")) move("backward");
+        if (canMove("forward")) move("forward");
+    }
+    if (y == closestEnemyBot.y) {
+        // Move up or down randomly if both directions are available
+        if (canMove("up") && canMove("down")) {
+            if (percentChance(50)) move("up");
+            move("down");
+        }
+        if (canMove("up")) move("up");
+        if (canMove("down")) move("down");
+    }
+
+    // Not in melee range...can we shoot something if there aren't too many enemies around?
+    // TODO add shared variable for retreating
+    // TODO: if other artillery in range, don't stand still
+    // TODO bug: will keep shooting at far enemy even if getting attacked by close enemy
+    if (numEnemyBots <= 2) {
+        if (willArtilleryHit()) {
+            gank = findEntity(ENEMY, BOT, SORT_BY_LIFE, SORT_ASCENDING);
+            if (getDistanceTo(gank) <= 7) fireArtillery(gank);
+            fireArtillery();
+        }
+    }
+
+    // There's an enemy nearby but we can't attack it, or there are too many.
+    // This assumes we are armed with artillery, which has min range 7, max range 10
+    if (enemyBotDistance < 6.5) {
+        debugLog(x + " " + y + " evading");
+        // Too close for comfort, let's try to get away
+        if (enemyBotDistance < 4 && canCloak()) {
+            // If they're really close and we can cloak, do that
+            cloak();
+        }
+        if (enemyBotDistance <= 4 && canReflect()) {
+            // Protect against missiles if we have reflection
+            reflect();
+        }
+        if (enemyBotDistance < 2.1 && canZap()) {
+            zap();
+        }
+
+        if (enemyBotDistance <= 2 && !isCloaked() && canCharge()) {
+            // We're backed into a corner. Charge!!
+            pursue(closestEnemyBot);
+        }
+
+        cornerDist = distanceToCorner();
+        // Charge more aggresively if cornered
+        if (enemyBotDistance <= 3 && distanceToCorner <= 2 && canCharge()) {
+            // We're backed into a corner. Charge!!
+            pursue(closestEnemyBot);
+        }
+
+        // If the enemy somehow got close, we can shoot it some of the time
+        // TODO better handle when we should shoot and when we should run
+        if (
+            enemyBotDistance <= 3 &&
+            willMissilesHit() &&
+            numEnemyBots <= 1 &&
+            percentChance(50)
+        ) {
+            gank = findEntity(ENEMY, BOT, SORT_BY_LIFE, SORT_ASCENDING);
+            if (getDistanceTo(gank) <= 3) fireMissiles(gank);
+            fireMissiles();
+        }
+
+        // Move away from the bot, preferably toward a border
+        // TODO artillery needs to be able to move forward
+
+        // We're diagonally (?) positioned from the enemy. Go in the direction with more space.
+        if (canMove("backward") && x <= closestEnemyBot.x) {
+            move("backward");
+        }
+        if (canMove("up") && y <= closestEnemyBot.y) {
+            move("up");
+        }
+        if (canMove("down") && y >= closestEnemyBot.y) {
+            move("down");
+        }
+        if (canMove("backward")) {
+            if (numEnemyBots > 1) move("backward");
+        }
+        if (canMove("forward") && x >= closestEnemyBot.x && numEnemyBots <= 1) {
+            move("forward");
+        }
+        if (canMove("backward")) {
+            move("backward");
+        }
+    }
+
+    if (willMissilesHit()) {
+        gank = findEntity(ENEMY, BOT, SORT_BY_LIFE, SORT_ASCENDING);
+        if (getDistanceTo(gank) <= 3) fireMissiles(gank);
+        fireMissiles();
+    }
+
+    if (canActivateSensors()) activateSensors();
+    // Random move
+    move();
+};

--- a/lib/bot.land.d.ts
+++ b/lib/bot.land.d.ts
@@ -72,6 +72,7 @@ declare function floor(n: number): number;
 declare function max(...nums: number[]): number;
 declare function min(...nums: number[]): number;
 declare function percentChance(chance: number): boolean;
+declare function round(n: number): number;
 declare function size(arr: any[]): number;
 
 // Functions - Movement

--- a/lib/bot.land.d.ts
+++ b/lib/bot.land.d.ts
@@ -82,7 +82,7 @@ declare function canMoveTo(x: number, y: number): boolean;
 declare function getDistanceTo(entity: Entity): number;
 declare function getDistanceTo(x: number, y: number): number;
 
-declare function move(dir: Direction): void;
+declare function move(dir?: Direction): void;
 declare function moveTo(entity: Entity): void;
 declare function moveTo(x: number, y: number): void;
 // Alias of moveTo

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -53,12 +53,12 @@ const getData = function(): any {
 
     const me = getEntityAt(x, y);
     // Load arrays
-    debugLog("array1 before data load", array1);
-    debugLog("array2 before data load", array2);
+    // debugLog("array1 before data load", array1);
+    // debugLog("array2 before data load", array2);
     array1 = sharedD;
     array2 = sharedE;
-    debugLog("array1 after data load", array1);
-    debugLog("array2 after data load", array2);
+    // debugLog("array1 after data load", array1);
+    // debugLog("array2 after data load", array2);
 
     let i = 0;
     for (i = 0; i < size(array2); i++) {
@@ -69,4 +69,9 @@ const getData = function(): any {
     }
     // Data not found
     return undefined;
+};
+
+const isNumber = function(value: any): boolean {
+    if (value == value + 0) return true;
+    else return false;
 };

--- a/lib/movement.ts
+++ b/lib/movement.ts
@@ -92,8 +92,8 @@ const attackerUpdateLocation = function(xCoord: number, yCoord: number): void {
  * @param enemy
  */
 const setEnemySeen = function(enemy: Entity): void {
-    // This is currently not used for attackers, and we don't want to bludgeon
-    // the shared variables.
+    // This is only used for defenders, at the moment, so avoid clobbering the
+    // shared variables that are currently used by attackers.
     if (isAttacker) return;
 
     // We store 2 locations (see README). Bots attack to whichever location is

--- a/lib/movement.ts
+++ b/lib/movement.ts
@@ -100,6 +100,7 @@ const attackerUpdateLocation = function(xCoord: number, yCoord: number): void {
 };
 
 const checkTeamCentroidMove = function(minDist: number, maxDist: number) {
+    if (!isAttacker) return;
     // Distances in bot land are manhattan distance
     const distToCentroid = abs(x - sharedA) + abs(y - sharedB);
 

--- a/lib/movement.ts
+++ b/lib/movement.ts
@@ -63,6 +63,8 @@ const defaultMove = function() {
  * this centroid the more they will be likely to move toward it.
  */
 const attackerUpdateLocation = function(xCoord: number, yCoord: number): void {
+    if (!isAttacker) return;
+
     // First turn update
     if (!exists(sharedA)) {
         sharedA = xCoord;

--- a/lib/movement.ts
+++ b/lib/movement.ts
@@ -52,8 +52,37 @@ const defaultMove = function() {
 };
 
 /**
+ * Attacker movement code works as follows:
+ *
+ * shared(A, B) records the centroid of the team. It is updated using a hacky
+ * exponentially-weighted moving average. Certain units update and respond to
+ * this EWMA (microing bots), while others just respond to it but don't update
+ * (repair bots).
+ *
+ * For bots that care about being near the group, the further away they are from
+ * this centroid the more they will be likely to move toward it.
+ */
+const attackerUpdateLocation = function(xCoord: number, yCoord: number): void {
+    // First turn update
+    if (!exists(sharedA)) {
+        sharedA = xCoord;
+        sharedB = yCoord;
+        return;
+    }
+
+    const alpha = 0.3;
+    // This is a weird EWMA, because we don't know the number of bots (as they
+    // die). With many bots it needs to be low enough that the average doesn't
+    // jump around a lot, but with a single bot it needs to be high enough that
+    // the bot can move around without impeding itself too much.
+    sharedA = xCoord * alpha + sharedA * (1 - alpha);
+    sharedB = yCoord * alpha + sharedB * (1 - alpha);
+};
+
+/**
  * We have seen some baddies. Setting this causes other bots to move accordingly
  * to the enemy's location.
+ * @param enemy
  */
 const setEnemySeen = function(enemy: Entity): void {
     // This is currently not used for attackers, and we don't want to bludgeon

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -49,6 +49,11 @@ const tryEvadeEnemy = function(closestEnemyBot: Entity, numEnemyBots: number) {
     // Prefer going backward to going forward, which can get us stuck.
     // TODO don't always run down from top left
     if (canMove("backward") && x <= closestEnemyBot.x) {
+        // Do occasional diagonal moves to get people to eat mines
+        if (y < closestEnemyBot.y && canMove("up") && percentChance(30))
+            move("up");
+        if (y > closestEnemyBot.y && canMove("down") && percentChance(30))
+            move("down");
         move("backward");
     }
     // TODO we should move backward when there's one bot too

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,15 +4,23 @@
  * @param closestEnemyBot entity representing the closest bot we see
  * @param numEnemyBots total number of enemy bots visible
  */
-const tryEvadeLasers = function(closestEnemyBot: Entity, numEnemyBots: number) {
+const tryEvadeLasers = function(
+    closestEnemyBot: Entity,
+    numEnemyBots: number,
+    weaponMaxRange: number
+) {
     const enemyBotDistance = getDistanceTo(closestEnemyBot);
+    // Mainly for artillery. Lasers have a max range of 5, so why dodge them at
+    // longer ranges? This occasionally helped with dodging artillery, but we
+    // should write separate code for that.
+    if (enemyBotDistance > 5) return;
+
     // Don't stand in range of lasers
     // Move away from the bot, preferably toward a border
     if (x == closestEnemyBot.x && enemyBotDistance > 1) {
-        // TODO hack for fixing the bouncing back and forth issue
-        // get in diag range with missiles
-        // TODO: consider values other than 4 for other weapons
-        if (enemyBotDistance >= 4 && percentChance(50)) {
+        // TODO hack for fixing the bouncing back and forth issue at maximum
+        // weapon range. This helps us get on a diagonal but still in range.
+        if (enemyBotDistance == weaponMaxRange && percentChance(50)) {
             if (y > closestEnemyBot.y && canMove("up")) move("up");
             else if (y < closestEnemyBot.y && canMove("down")) move("down");
         }
@@ -90,10 +98,18 @@ const tryMeleeSmart = function() {
  */
 const tryFireMissiles = function() {
     if (willMissilesHit()) {
-        const gankTarget = findEntity(ENEMY, BOT, SORT_BY_LIFE, SORT_ASCENDING);
-        if (willMissilesHit(gankTarget)) fireMissiles(gankTarget);
+        const gank = findEntity(ENEMY, BOT, SORT_BY_LIFE, SORT_ASCENDING);
+        if (willMissilesHit(gank)) fireMissiles(gank);
         // If not, fire at anyone
         fireMissiles();
+    }
+};
+
+const tryFireArtillery = function() {
+    if (willArtilleryHit()) {
+        const gank = findEntity(ENEMY, BOT, SORT_BY_LIFE, SORT_ASCENDING);
+        if (willArtilleryHit(gank)) fireArtillery(gank);
+        fireArtillery();
     }
 };
 


### PR DESCRIPTION
Once this PR is completed, it will close #16.

TODOs:

- [x] EWMA movement code for attacking micro artillery and missiles (and aggro miners)
- [x] bot counter for getting update weight
- [ ] Attacking artillery can be willing to not wait for sensors when it has more health (esp w/ regen) - this is implemented with the `AGGRESSIVE` flag
- [x] Defending artillery never waits for sensors (but does turn them on if no enemies are visible) and has an evade distance of 5 instead of 7 
- [ ] Artillery should not lay mines when sensors are on and no enemies within 5 range
- [ ] Artillery should not ignore other units when shooting at CPU; `tryFireArtillery()` will shoot a chip or CPU even if we are getting bashed by a bot.
- [x] Mine layers should back up in different directions (closes #30)
- [x] Aggro miner is a good distract bot (closes #20)

Add artillery to defense once done!
