### PR TITLE
Chaos zapping

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,10 +20,7 @@
                 "s/var //g",
                 "MissileKite/bot.js"
             ],
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            },
+            "group": "build",
             "dependsOn": [
                 "MissileKite compile"
             ],
@@ -47,7 +44,10 @@
                 "s/var //g",
                 "ZapKite/bot.js"
             ],
-            "group": "build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
             "dependsOn": [
                 "ZapKite compile"
             ],

--- a/MissileKite/MissileKite.ts
+++ b/MissileKite/MissileKite.ts
@@ -18,19 +18,13 @@
  * high reflect and no thrusters (it saves 1 reflection).
  */
 const update = function() {
-    // If it's the first round of the game, take a shot before anyone turns on
-    // reflection. This is especially advantageous for defenders who seem to get
-    // their turns first before attackers.
-    //
-    // TODO: this is janky because it depends on number of bots we have in the arena.
-    let potshotThreshold = 5;
-    if (isAttacker) potshotThreshold = 4;
-    if (!exists(sharedE) || sharedE < potshotThreshold) {
-        if (!exists(sharedE)) sharedE = 1;
-        else sharedE = sharedE + 1;
+    const state = getData();
+    if (!exists(state)) {
+        // Need to save in case we reach a terminator
+        saveData("first turn done");
         // As defender, try to cast shield on anyone nearby
         if (!isAttacker && canShield()) {
-            debugLog("Casting first turn defender shield");
+            debugLog("Casting defender first turn shield");
             shieldTanks();
         }
         // If first turn of the game, take a shot before anyone turns on

--- a/SmartMelee/tsconfig.json
+++ b/SmartMelee/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es3",
     "module": "none",
+    "removeComments": true,
     "sourceMap": false,
     "outFile": "bot.js"
   },

--- a/ZapKite/ZapKite.ts
+++ b/ZapKite/ZapKite.ts
@@ -27,7 +27,9 @@ const update = function() {
     if (counter % CYCLEN == 0) {
         tryCloak();
     } else if (counter % CYCLEN == 2) {
+        // If we have defensive measures try activating before uncloak
         tryReflect();
+        tryShieldSelf();
     } else if (counter % CYCLEN == 3) {
         tryZap();
     }
@@ -83,7 +85,7 @@ const update = function() {
     tryMeleeSmart();
 
     // Do anything that moves. If we're not next to them move closer.
-    if (enemyBotDistance > 1) moveTo(closestEnemy);
+    if (enemyBotDistance > 1) moveTo(closestEnemyBot);
 
     // Otherwise we're right next to the enemy. So based on whereever they are,
     // move toward the side with MORE people. We don't even need to go backward
@@ -118,7 +120,6 @@ const update = function() {
         else if (botValid) moveTo(x, botY);
     }
 
-    if (willMeleeHit()) melee();
     defaultMove();
 };
 

--- a/ZapKite/tsconfig.json
+++ b/ZapKite/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es3",
     "module": "none",
+    "removeComments": true,
     "sourceMap": false,
     "outFile": "bot.js"
   },

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,12 @@
+# Shared Variables
+
+There are 5 shared variables, A-E. Bots on a team use these as follows:
+
+-   sharedA = [x1, y1]: location of one last seen enemy
+-   sharedB = [x2, y2]: location of second last seen enemy, that is not close to
+    the first.
+-   sharedC = [xc, yc]: team centroid, updated with an exponentially-weighted
+    moving average.
+-   sharedD = any[]: a state variable for each bot that it can store and retrieve.
+-   sharedE = Entity[]: an Entity for each bot on the team, with the same order as
+    sharedD.

--- a/lib/bot.land.d.ts
+++ b/lib/bot.land.d.ts
@@ -40,7 +40,7 @@ declare type Direction =
 // Terminators
 
 // Functions
-declare function debugLog(msg: string): void;
+declare function debugLog(stuff: any): void;
 declare function exists(entity?: Entity): boolean;
 
 declare function findEntities(
@@ -106,8 +106,10 @@ declare function canActivateSensors(): boolean;
 declare function areSensorsActivated(): boolean;
 declare function cloak(): void;
 declare function canCloak(): boolean;
+declare function isCloaked(): boolean;
 declare function reflect(): void;
 declare function canReflect(): boolean;
+declare function isReflecting(): boolean;
 declare function shield(entity?: Entity): void;
 declare function canShield(entity?: Entity): boolean;
 declare function isShielded(entity?: Entity): boolean;

--- a/lib/bot.land.d.ts
+++ b/lib/bot.land.d.ts
@@ -40,8 +40,8 @@ declare type Direction =
 // Terminators
 
 // Functions
-declare function debugLog(stuff: any): void;
-declare function exists(entity?: Entity): boolean;
+declare function debugLog(...stuff: any[]): void;
+declare function exists(thing: any): boolean;
 
 declare function findEntities(
     friendlyOrEnemy: EntityMatchFlags,
@@ -63,8 +63,8 @@ declare function findEntity(
 declare function getEntityAt(x: number, y: number): Entity;
 declare function figureItOut(): void;
 
-declare let array1: Entity[];
-declare let array2: Entity[];
+declare let array1: any[];
+declare let array2: any[];
 
 // Functions - Math
 declare function abs(n: number): number;

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,69 @@
+/**
+ * Utilities for bots to save data across turns about themselves. Enables crazy
+ * things like the chaos zapper.
+ *
+ * This uses sharedD to store data, and sharedE to store corresponding entities
+ * for that data.
+ *
+ * TODO: this will conflict with missile micro potshots, so we need to have that
+ * use this system when merging.
+ */
+const saveData = function(datum): void {
+    const me = getEntityAt(x, y);
+    if (!exists(sharedE)) {
+        // We are the first person to save data, put ourselves in position 1
+        array1 = [];
+        array2 = [];
+        array1[0] = datum;
+        array2[0] = me;
+        sharedD = array1;
+        sharedE = array2;
+        return;
+    }
+
+    // Load arrays from shared variables
+    array1 = sharedD;
+    array2 = sharedE;
+
+    let i = 0;
+    for (i = 0; i < size(array2); i++) {
+        if (array2[i] == me) {
+            // That's my data!
+            array1[i] = datum;
+            // No change to entity
+            sharedD = array1;
+            sharedE = array2;
+            return;
+        }
+    }
+
+    // We weren't in the array, insert ourselves at the end
+    array1[i] = datum;
+    array2[i] = me;
+    debugLog("Saved " + datum + " for " + me);
+    debugLog(i);
+    debugLog(array1);
+    debugLog(array2);
+    sharedD = array1;
+    sharedE = array2;
+};
+
+const getData = function(): any {
+    // No data saved yet
+    if (!exists(sharedE)) return undefined;
+
+    const me = getEntityAt(x, y);
+    // Load arrays
+    array1 = sharedD;
+    array2 = sharedE;
+
+    let i = 0;
+    for (i = 0; i < size(array2); i++) {
+        if (array2[i] == me) {
+            // That's my data!
+            return array1[i];
+        }
+    }
+    // Data not found
+    return undefined;
+};

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -41,9 +41,8 @@ const saveData = function(datum): void {
     array1[i] = datum;
     array2[i] = me;
     debugLog("Saved " + datum + " for " + me);
-    debugLog(i);
-    debugLog(array1);
     debugLog(array2);
+    debugLog(array1);
     sharedD = array1;
     sharedE = array2;
 };
@@ -54,8 +53,12 @@ const getData = function(): any {
 
     const me = getEntityAt(x, y);
     // Load arrays
+    debugLog("array1 before data load", array1);
+    debugLog("array2 before data load", array2);
     array1 = sharedD;
     array2 = sharedE;
+    debugLog("array1 after data load", array1);
+    debugLog("array2 after data load", array2);
 
     let i = 0;
     for (i = 0; i < size(array2); i++) {

--- a/lib/movement.ts
+++ b/lib/movement.ts
@@ -56,6 +56,10 @@ const defaultMove = function() {
  * to the enemy's location.
  */
 const setEnemySeen = function(enemy: Entity): void {
+    // This is currently not used for attackers, and we don't want to bludgeon
+    // the shared variables.
+    if (isAttacker) return;
+
     // There are 5 shared variables, A-E.
     // - shared(A,B): location of one last seen enemy
     // - shared(C,D): location of second last seen enemy, that is not close to


### PR DESCRIPTION
Closes #25.

One idea: Combine with a distract bot that lures out enemy units one by one that the chaos zappers murder.

TODOs:
- [x] Update missile bots to use new data store
- [x] Should not attack chips when enemies are nearby
- [x] Add shield to chaos zapping